### PR TITLE
feat: Add category `other`

### DIFF
--- a/aws.sh
+++ b/aws.sh
@@ -1,12 +1,28 @@
 #!/bin/sh
 
-set -e
+set -eu
+
+OTHER_JSON=$(cat <<'EOF'
+{ "id": "aws/other", "name": "Other",
+  "summary": "Other AWS services.",
+  "url": "",
+  "categories": [
+    {
+      "id": "other",
+      "name": "Other"
+    }
+  ],
+  "tags": ["aws/platform"]
+}
+EOF
+)
 
 echo "listing AWS services"
 
 curl -s 'https://aws.amazon.com/api/dirs/items/search?item.directoryId=aws-products&sort_by=item.additionalFields.productCategory&sort_order=asc&size=500&item.locale=en_US&tags.id=!aws-products%23type%23feature&tags.id=!aws-products%23type%23variant' \
   | jq -r '.items[] | {"id": "aws/\(.item.name)", "name": .item.additionalFields.productName, "summary": .item.additionalFields.productSummary, "url": .item.additionalFields.productUrl, "categories": [.tags[] | select(.tagNamespaceId=="GLOBAL#tech-category") | {"id": (.name | gsub(" "; "-") | gsub("&"; "and") | ascii_downcase), "name": .description}], "tags": ["aws/platform", "aws/service/\(.item.name)", "aws/category/\(.tags[] | select(.tagNamespaceId=="GLOBAL#tech-category") | .name | gsub(" "; "-") | gsub("&"; "and") | ascii_downcase)"] }' \
   | jq -n '. |= [inputs]' \
+  | jq -r ". += [$OTHER_JSON]" \
   | jq -r 'sort_by(.id)' > data/aws.json
 
 # fix wrong category descriptions

--- a/data/aws.json
+++ b/data/aws.json
@@ -3819,6 +3819,21 @@
     ]
   },
   {
+    "id": "aws/other",
+    "name": "Other",
+    "summary": "Other AWS services.",
+    "url": "",
+    "categories": [
+      {
+        "id": "other",
+        "name": "Other"
+      }
+    ],
+    "tags": [
+      "aws/platform"
+    ]
+  },
+  {
     "id": "aws/pytorch-on-aws",
     "name": "PyTorch on AWS",
     "summary": "Flexible open-source machine learning framework",

--- a/data/aws.json
+++ b/data/aws.json
@@ -17,24 +17,24 @@
     "url": "https://aws.amazon.com/api-gateway",
     "categories": [
       {
+        "id": "front-end-web-and-mobile",
+        "name": "Front-End Web & Mobile"
+      },
+      {
         "id": "serverless",
         "name": "Serverless"
       },
       {
         "id": "networking-and-content-delivery",
         "name": "Networking & Content Delivery"
-      },
-      {
-        "id": "front-end-web-and-mobile",
-        "name": "Front-End Web & Mobile"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-api-gateway",
+      "aws/category/front-end-web-and-mobile",
       "aws/category/serverless",
-      "aws/category/networking-and-content-delivery",
-      "aws/category/front-end-web-and-mobile"
+      "aws/category/networking-and-content-delivery"
     ]
   },
   {
@@ -95,14 +95,14 @@
     "url": "https://aws.amazon.com/augmented-ai",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-augmented-ai",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -129,14 +129,14 @@
     "url": "https://aws.amazon.com/braket",
     "categories": [
       {
-        "id": "quantum",
+        "id": "quantum-technologies",
         "name": "Quantum Technologies"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-braket",
-      "aws/category/quantum"
+      "aws/category/quantum-technologies"
     ]
   },
   {
@@ -212,15 +212,15 @@
         "name": "Developer Tools"
       },
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-codeguru",
       "aws/category/developer-tools",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -247,14 +247,14 @@
     "url": "https://aws.amazon.com/comprehend",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-comprehend",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -309,14 +309,14 @@
     "url": "https://aws.amazon.com/devops-guru",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-devops-guru",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -455,19 +455,19 @@
     "url": "https://aws.amazon.com/ecs",
     "categories": [
       {
-        "id": "containers",
-        "name": "Containers"
-      },
-      {
         "id": "compute",
         "name": "Compute"
+      },
+      {
+        "id": "containers",
+        "name": "Containers"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-elastic-container-service-ecs",
-      "aws/category/containers",
-      "aws/category/compute"
+      "aws/category/compute",
+      "aws/category/containers"
     ]
   },
   {
@@ -494,14 +494,14 @@
     "url": "https://aws.amazon.com/machine-learning/elastic-inference",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-elastic-inference",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -511,19 +511,19 @@
     "url": "https://aws.amazon.com/eks",
     "categories": [
       {
-        "id": "containers",
-        "name": "Containers"
-      },
-      {
         "id": "compute",
         "name": "Compute"
+      },
+      {
+        "id": "containers",
+        "name": "Containers"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-elastic-kubernetes-service-eks",
-      "aws/category/containers",
-      "aws/category/compute"
+      "aws/category/compute",
+      "aws/category/containers"
     ]
   },
   {
@@ -601,19 +601,19 @@
     "url": "https://aws.amazon.com/eventbridge",
     "categories": [
       {
-        "id": "application-integration",
-        "name": "Application Integration"
-      },
-      {
         "id": "serverless",
         "name": "Serverless"
+      },
+      {
+        "id": "application-integration",
+        "name": "Application Integration"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-eventbridge",
-      "aws/category/application-integration",
-      "aws/category/serverless"
+      "aws/category/serverless",
+      "aws/category/application-integration"
     ]
   },
   {
@@ -640,14 +640,14 @@
     "url": "https://aws.amazon.com/forecast",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-forecast",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -657,14 +657,14 @@
     "url": "https://aws.amazon.com/fraud-detector",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-fraud-detector",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -753,14 +753,14 @@
     "url": "https://aws.amazon.com/healthlake",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-healthlake",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -815,14 +815,14 @@
     "url": "https://aws.amazon.com/kendra",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-kendra",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -883,14 +883,14 @@
     "url": "https://aws.amazon.com/lex",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-lex",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -934,14 +934,14 @@
     "url": "https://aws.amazon.com/lookout-for-equipment",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-lookout-for-equipment",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -951,14 +951,14 @@
     "url": "https://aws.amazon.com/lookout-for-metrics",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-lookout-for-metrics",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -968,14 +968,14 @@
     "url": "https://aws.amazon.com/lookout-for-vision",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-lookout-for-vision",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -1115,14 +1115,14 @@
     "url": "https://aws.amazon.com/monitron",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-monitron",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -1183,14 +1183,14 @@
     "url": "https://aws.amazon.com/personalize",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-personalize",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -1217,14 +1217,14 @@
     "url": "https://aws.amazon.com/polly",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-polly",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -1324,14 +1324,14 @@
     "url": "https://aws.amazon.com/rekognition",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-rekognition",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -1380,14 +1380,14 @@
     "url": "https://aws.amazon.com/sagemaker",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-sagemaker",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -1397,14 +1397,14 @@
     "url": "https://aws.amazon.com/sagemaker/groundtruth",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-sagemaker-ground-truth",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -1431,19 +1431,19 @@
     "url": "https://aws.amazon.com/sns",
     "categories": [
       {
-        "id": "application-integration",
-        "name": "Application Integration"
-      },
-      {
         "id": "serverless",
         "name": "Serverless"
+      },
+      {
+        "id": "application-integration",
+        "name": "Application Integration"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-simple-notification-service-sns",
-      "aws/category/application-integration",
-      "aws/category/serverless"
+      "aws/category/serverless",
+      "aws/category/application-integration"
     ]
   },
   {
@@ -1453,19 +1453,36 @@
     "url": "https://aws.amazon.com/sqs",
     "categories": [
       {
-        "id": "application-integration",
-        "name": "Application Integration"
-      },
-      {
         "id": "serverless",
         "name": "Serverless"
+      },
+      {
+        "id": "application-integration",
+        "name": "Application Integration"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-simple-queue-service-sqs",
-      "aws/category/application-integration",
-      "aws/category/serverless"
+      "aws/category/serverless",
+      "aws/category/application-integration"
+    ]
+  },
+  {
+    "id": "aws/amazon-sumerian",
+    "name": "Amazon Sumerian",
+    "summary": "Build and run AR and VR applications",
+    "url": "https://aws.amazon.com/sumerian",
+    "categories": [
+      {
+        "id": "ar-and-vr",
+        "name": "AR & VR"
+      }
+    ],
+    "tags": [
+      "aws/platform",
+      "aws/service/amazon-sumerian",
+      "aws/category/ar-and-vr"
     ]
   },
   {
@@ -1475,14 +1492,14 @@
     "url": "https://aws.amazon.com/textract",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-textract",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -1509,14 +1526,14 @@
     "url": "https://aws.amazon.com/transcribe",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-transcribe",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -1526,14 +1543,14 @@
     "url": "https://aws.amazon.com/translate",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/amazon-translate",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -1599,14 +1616,14 @@
     "url": "https://aws.amazon.com/mxnet",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/apache-mxnet-on-aws",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -1701,19 +1718,19 @@
     "url": "https://aws.amazon.com/appsync",
     "categories": [
       {
-        "id": "serverless",
-        "name": "Serverless"
-      },
-      {
         "id": "front-end-web-and-mobile",
         "name": "Front-End Web & Mobile"
+      },
+      {
+        "id": "serverless",
+        "name": "Serverless"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/aws-appsync",
-      "aws/category/serverless",
-      "aws/category/front-end-web-and-mobile"
+      "aws/category/front-end-web-and-mobile",
+      "aws/category/serverless"
     ]
   },
   {
@@ -2328,14 +2345,14 @@
     "url": "https://aws.amazon.com/machine-learning/amis",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/aws-deep-learning-amis",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -2345,14 +2362,14 @@
     "url": "https://aws.amazon.com/machine-learning/containers",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/aws-deep-learning-containers",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -2362,14 +2379,14 @@
     "url": "https://aws.amazon.com/deepcomposer",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/aws-deepcomposer",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -2379,14 +2396,14 @@
     "url": "https://aws.amazon.com/deeplens",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/aws-deeplens",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -2396,14 +2413,14 @@
     "url": "https://aws.amazon.com/deepracer",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/aws-deepracer",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -2622,24 +2639,24 @@
     "url": "https://aws.amazon.com/fargate",
     "categories": [
       {
-        "id": "containers",
-        "name": "Containers"
+        "id": "serverless",
+        "name": "Serverless"
       },
       {
         "id": "compute",
         "name": "Compute"
       },
       {
-        "id": "serverless",
-        "name": "Serverless"
+        "id": "containers",
+        "name": "Containers"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/aws-fargate",
-      "aws/category/containers",
+      "aws/category/serverless",
       "aws/category/compute",
-      "aws/category/serverless"
+      "aws/category/containers"
     ]
   },
   {
@@ -2751,14 +2768,14 @@
     "url": "https://aws.amazon.com/machine-learning/inferentia",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/aws-inferentia",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -3040,19 +3057,19 @@
     "url": "https://aws.amazon.com/lambda",
     "categories": [
       {
-        "id": "compute",
-        "name": "Compute"
-      },
-      {
         "id": "serverless",
         "name": "Serverless"
+      },
+      {
+        "id": "compute",
+        "name": "Compute"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/aws-lambda",
-      "aws/category/compute",
-      "aws/category/serverless"
+      "aws/category/serverless",
+      "aws/category/compute"
     ]
   },
   {
@@ -3232,14 +3249,14 @@
     "url": "https://aws.amazon.com/panorama",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/aws-panorama",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -3436,19 +3453,19 @@
     "url": "https://aws.amazon.com/serverless/serverlessrepo",
     "categories": [
       {
-        "id": "compute",
-        "name": "Compute"
-      },
-      {
         "id": "serverless",
         "name": "Serverless"
+      },
+      {
+        "id": "compute",
+        "name": "Compute"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/aws-serverless-application-repository",
-      "aws/category/compute",
-      "aws/category/serverless"
+      "aws/category/serverless",
+      "aws/category/compute"
     ]
   },
   {
@@ -3526,19 +3543,19 @@
     "url": "https://aws.amazon.com/step-functions",
     "categories": [
       {
-        "id": "application-integration",
-        "name": "Application Integration"
-      },
-      {
         "id": "serverless",
         "name": "Serverless"
+      },
+      {
+        "id": "application-integration",
+        "name": "Application Integration"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/aws-step-functions",
-      "aws/category/application-integration",
-      "aws/category/serverless"
+      "aws/category/serverless",
+      "aws/category/application-integration"
     ]
   },
   {
@@ -3735,9 +3752,9 @@
   },
   {
     "id": "aws/cloudeendure-disaster-recovery",
-    "name": "CloudEndure Disaster Recovery",
-    "summary": "Highly automated disaster recovery",
-    "url": "https://aws.amazon.com/cloudendure-disaster-recovery",
+    "name": "AWS Elastic Disaster Recovery (DRS)",
+    "summary": "<p>Scalable, cost-effective application recovery to AWS</p>",
+    "url": "https://aws.amazon.com/disaster-recovery",
     "categories": [
       {
         "id": "storage",
@@ -3752,9 +3769,9 @@
   },
   {
     "id": "aws/cloudendure-migration",
-    "name": "CloudEndure Migration",
-    "summary": "Automated lift-and-shift migration",
-    "url": "https://aws.amazon.com/cloudendure-migration",
+    "name": "AWS Application Migration Service (MGN)",
+    "summary": "<p>Automate application migration and modernization</p>",
+    "url": "https://aws.amazon.com/application-migration-service",
     "categories": [
       {
         "id": "migration",
@@ -3808,14 +3825,14 @@
     "url": "https://aws.amazon.com/pytorch",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/pytorch-on-aws",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {
@@ -3876,14 +3893,14 @@
     "url": "https://aws.amazon.com/tensorflow",
     "categories": [
       {
-        "id": "ai-ml",
-        "name": "Machine Learning"
+        "id": "machine-learning-and-ai",
+        "name": "Machine Learning & AI"
       }
     ],
     "tags": [
       "aws/platform",
       "aws/service/tensorflow-on-aws",
-      "aws/category/ai-ml"
+      "aws/category/machine-learning-and-ai"
     ]
   },
   {

--- a/data/gcp.json
+++ b/data/gcp.json
@@ -2590,6 +2590,21 @@
     ]
   },
   {
+    "id": "gcp/other",
+    "name": "Other",
+    "summary": "Other GCP services.",
+    "url": "",
+    "categories": [
+      {
+        "id": "other",
+        "name": "Other"
+      }
+    ],
+    "tags": [
+      "gcp/platform"
+    ]
+  },
+  {
     "id": "gcp/packet-mirroring",
     "name": "Packet Mirroring",
     "summary": "Packet Mirroring clones the traffic of specified instances in your Virtual Private Cloud (VPC) network and forwards it for examination.",

--- a/data/gcp.json
+++ b/data/gcp.json
@@ -479,6 +479,23 @@
     ]
   },
   {
+    "id": "gcp/biglake",
+    "name": "BigLake",
+    "summary": "Storage engine for unifying data warehouses and lakes.",
+    "url": "https://cloud.google.com/biglake",
+    "categories": [
+      {
+        "id": "data-analytics",
+        "name": "data analytics"
+      }
+    ],
+    "tags": [
+      "gcp/platform",
+      "gcp/service/biglake",
+      "gcp/category/data-analytics"
+    ]
+  },
+  {
     "id": "gcp/bigquery",
     "name": "BigQuery",
     "summary": "Data warehouse for business agility and insights.",
@@ -2286,6 +2303,23 @@
     ]
   },
   {
+    "id": "gcp/live-stream-api",
+    "name": "Live Stream API",
+    "summary": "Live encoder that transforms live video content for use across a variety of user devices.",
+    "url": "/livestream",
+    "categories": [
+      {
+        "id": "media-and-gaming",
+        "name": "media and gaming"
+      }
+    ],
+    "tags": [
+      "gcp/platform",
+      "gcp/service/live-stream-api",
+      "gcp/category/media-and-gaming"
+    ]
+  },
+  {
     "id": "gcp/local-ssd",
     "name": "Local SSD",
     "summary": "Block storage that is locally attached for high-performance needs.",
@@ -2413,7 +2447,7 @@
     "id": "gcp/migrate-for-anthos",
     "name": "Migrate for Anthos",
     "summary": "Tool to move workloads and existing applications to GKE.",
-    "url": "https://cloud.google.com/migrate/anthos",
+    "url": "/migrate/anthos",
     "categories": [
       {
         "id": "hybrid-and-multicloud",
@@ -2435,7 +2469,7 @@
     "id": "gcp/migrate-for-compute-engine",
     "name": "Migrate for Compute Engine",
     "summary": "Server and virtual machine migration to Compute Engine.",
-    "url": "https://cloud.google.com/migrate/compute-engine",
+    "url": "/migrate/compute-engine",
     "categories": [
       {
         "id": "compute",
@@ -3243,6 +3277,23 @@
       "gcp/platform",
       "gcp/service/video-ai",
       "gcp/category/ai-and-machine-learning"
+    ]
+  },
+  {
+    "id": "gcp/video-stitcher-api",
+    "name": "Video Stitcher API",
+    "summary": "Dynamically insert content and ads for targeted personalization of VOD and live content.",
+    "url": "/video-stitcher",
+    "categories": [
+      {
+        "id": "media-and-gaming",
+        "name": "media and gaming"
+      }
+    ],
+    "tags": [
+      "gcp/platform",
+      "gcp/service/video-stitcher-api",
+      "gcp/category/media-and-gaming"
     ]
   },
   {

--- a/gcp.sh
+++ b/gcp.sh
@@ -1,6 +1,23 @@
 #!/bin/sh
 
-set -e
+set -eu
+
+OTHER_JSON=$(cat <<'EOF'
+ {
+	"id": "gcp/other",
+	"name": "Other",
+	"summary": "Other GCP services.",
+	"url": "",
+	"categories": [
+		{
+			"id": "other",
+			"name": "Other"
+		}
+	],
+	"tags": ["gcp/platform"]
+}
+EOF
+)
 
 echo "listing GCP services"
 
@@ -11,6 +28,7 @@ curl -s 'https://cloud.google.com/products/' \
   | jq '. | group_by(.id) | map(.[] + {("categories"): map(.categories) | add}) | unique_by(.id)' \
   | jq '.[] | . + {"tags": ["gcp/platform", ("gcp/service/" + .id | sub("/gcp/"; "/")), "gcp/category/\(.categories[] | .id)"]}' \
   | jq -n '. |= [inputs]' \
+  | jq -r ". += [$OTHER_JSON]" \
   | jq -r 'sort_by(.id)' > data/gcp.json
 
 echo "done"


### PR DESCRIPTION
Son of #4: This is how we could add the `other` category in a sustainable manner.

Context: If understand correctly, this seems to be a feature that product is really keen on, based by customer demand, I assume.

We still need a process for dealing with these "half-classified" tickets.

I do see some merit in this, even for CREs; e.g. when re-assigning tickets to other departments. Still I think we need a [CEP](https://doitintl.atlassian.net/wiki/spaces/CRE/pages/18616621/CEPs+-+CRE+Enhancement+proposals.) before we can accept this.

Closes #4.