### PR TITLE
filter workspace services from gcp, add to gsuite.json

### DIFF
--- a/custom-services/gsuite.json
+++ b/custom-services/gsuite.json
@@ -119,23 +119,6 @@
     ]
   },
   {
-    "id": "gsuite/endpoint-management",
-    "name": "Endpoint Management",
-    "summary": "Endpoint management provides device management from one place for Android, iOS, Windows, Chrome OS, MacOS, and Linux.",
-    "url": "https://workspace.google.com/products/admin/endpoint/",
-    "categories": [
-      {
-        "id": "security-and-identity",
-        "name": "security and identity"
-      }
-    ],
-    "tags": [
-      "gsuite/platform",
-      "gsuite/service/endpoint-management",
-      "gsuite/category/security-and-identity"
-    ]
-  },
-  {
     "id": "gsuite/forms",
     "name": "Forms",
     "summary": "Easy to create surveys and forms for everyone.",
@@ -221,23 +204,6 @@
     ]
   },
   {
-    "id": "gsuite/security-center",
-    "name": "Security center",
-    "summary": "Protect your organization with security analytics and best practice recommendations from Google. Actionable security insights for Google Workspace.",
-    "url": "https://workspace.google.com/products/admin/security-center/",
-    "categories": [
-      {
-        "id": "security-and-identity",
-        "name": "security and identity"
-      }
-    ],
-    "tags": [
-      "gsuite/platform",
-      "gsuite/service/security-center",
-      "gsuite/category/security-and-identity"
-    ]
-  },
-  {
     "id": "gsuite/sheets",
     "name": "Sheets",
     "summary": "Collaborative, smart, secure spreadsheets for fast-moving organizations.",
@@ -269,23 +235,6 @@
       "gsuite/platform",
       "gsuite/category/applications",
       "gsuite/service/sites"
-    ]
-  },
-  {
-    "id": "gsuite/vault",
-    "name": "Vault",
-    "summary": "Data retention and eDiscovery for Google Workspace.",
-    "url": "https://workspace.google.com/products/vault/",
-    "categories": [
-      {
-        "id": "security-and-identity",
-        "name": "security and identity"
-      }
-    ],
-    "tags": [
-      "gsuite/platform",
-      "gsuite/service/vault",
-      "gsuite/category/security-and-identity"
     ]
   },
   {

--- a/data/gcp.json
+++ b/data/gcp.json
@@ -1861,23 +1861,6 @@
     ]
   },
   {
-    "id": "gcp/endpoint-management",
-    "name": "Endpoint Management",
-    "summary": "Endpoint management provides device management from one place for Android, iOS, Windows, Chrome OS, MacOS, and Linux.",
-    "url": "https://cloud.google.comhttps://workspace.google.com/products/admin/endpoint/",
-    "categories": [
-      {
-        "id": "security-and-identity",
-        "name": "security and identity"
-      }
-    ],
-    "tags": [
-      "gcp/platform",
-      "gcp/service/endpoint-management",
-      "gcp/category/security-and-identity"
-    ]
-  },
-  {
     "id": "gcp/filestore",
     "name": "Filestore",
     "summary": "File storage that is highly scalable and secure.",
@@ -2113,57 +2096,6 @@
       "gcp/platform",
       "gcp/service/google-marketing-platform",
       "gcp/category/data-analytics"
-    ]
-  },
-  {
-    "id": "gcp/google-meet",
-    "name": "Google Meet",
-    "summary": "Easy-to-join video meetings.",
-    "url": "https://cloud.google.comhttps://workspace.google.com/products/meet/",
-    "categories": [
-      {
-        "id": "more-cloud-offerings",
-        "name": "more cloud offerings"
-      }
-    ],
-    "tags": [
-      "gcp/platform",
-      "gcp/service/google-meet",
-      "gcp/category/more-cloud-offerings"
-    ]
-  },
-  {
-    "id": "gcp/google-workspace",
-    "name": "Google Workspace",
-    "summary": "Google Workspace brings together the apps loved by billions of people—Gmail, Chat, Calendar, Drive, Docs, Sheets, Meet, and more—into a single integrated workspace.",
-    "url": "https://cloud.google.comhttps://workspace.google.com",
-    "categories": [
-      {
-        "id": "more-cloud-offerings",
-        "name": "more cloud offerings"
-      }
-    ],
-    "tags": [
-      "gcp/platform",
-      "gcp/service/google-workspace",
-      "gcp/category/more-cloud-offerings"
-    ]
-  },
-  {
-    "id": "gcp/google-workspace-essentials",
-    "name": "Google  Workspace Essentials",
-    "summary": "Cloud-based file sharing, content collaboration, and storage.",
-    "url": "https://cloud.google.comhttps://workspace.google.com/essentials/",
-    "categories": [
-      {
-        "id": "storage",
-        "name": "storage"
-      }
-    ],
-    "tags": [
-      "gcp/platform",
-      "gcp/service/google-workspace-essentials",
-      "gcp/category/storage"
     ]
   },
   {
@@ -2935,23 +2867,6 @@
     ]
   },
   {
-    "id": "gcp/security-center",
-    "name": "Security center",
-    "summary": "Protect your organization with security analytics and best practice recommendations from Google. Actionable security insights for Google Workspace.",
-    "url": "https://cloud.google.comhttps://workspace.google.com/products/admin/security-center/",
-    "categories": [
-      {
-        "id": "security-and-identity",
-        "name": "security and identity"
-      }
-    ],
-    "tags": [
-      "gcp/platform",
-      "gcp/service/security-center",
-      "gcp/category/security-and-identity"
-    ]
-  },
-  {
     "id": "gcp/security-command-center",
     "name": "Security Command Center",
     "summary": "Platform for defending against threats to your Google Cloud assets.",
@@ -3294,23 +3209,6 @@
       "gcp/platform",
       "gcp/service/translation-ai",
       "gcp/category/ai-and-machine-learning"
-    ]
-  },
-  {
-    "id": "gcp/vault",
-    "name": "Vault",
-    "summary": "Data retention and eDiscovery for Google Workspace.",
-    "url": "https://cloud.google.comhttps://workspace.google.com/products/vault/",
-    "categories": [
-      {
-        "id": "security-and-identity",
-        "name": "security and identity"
-      }
-    ],
-    "tags": [
-      "gcp/platform",
-      "gcp/service/vault",
-      "gcp/category/security-and-identity"
     ]
   },
   {

--- a/data/gsuite.json
+++ b/data/gsuite.json
@@ -125,7 +125,7 @@
     "url": "https://workspace.google.com/products/admin/endpoint/",
     "categories": [
       {
-        "id": "security-and-identity",
+        "id": "gsuite/security-and-identity",
         "name": "security and identity"
       }
     ],
@@ -227,7 +227,7 @@
     "url": "https://workspace.google.com/products/admin/security-center/",
     "categories": [
       {
-        "id": "security-and-identity",
+        "id": "gsuite/security-and-identity",
         "name": "security and identity"
       }
     ],
@@ -278,7 +278,7 @@
     "url": "https://workspace.google.com/products/vault/",
     "categories": [
       {
-        "id": "security-and-identity",
+        "id": "gsuite/security-and-identity",
         "name": "security and identity"
       }
     ],

--- a/gcp.sh
+++ b/gcp.sh
@@ -8,7 +8,7 @@ CUSTOM_SERVICES=$(cat custom-services/gcp.json)
 curl -s 'https://cloud.google.com/products/' \
   | pup 'a.cws-card json{}' \
   | jq -r '.[]
-          # workspace services are covered by gsuite plafform
+          # workspace services are covered by gsuite platform
           | select(.href | startswith("https://workspace.google.com") | not )
           | {
               "id": ("gcp/" + ."track-name" | gsub(" ";"-")),

--- a/gcp.sh
+++ b/gcp.sh
@@ -8,6 +8,8 @@ CUSTOM_SERVICES=$(cat custom-services/gcp.json)
 curl -s 'https://cloud.google.com/products/' \
   | pup 'a.cws-card json{}' \
   | jq -r '.[]
+          # workspace services are covered by gsuite plafform
+          | select(.href | startswith("https://workspace.google.com") | not )
           | {
               "id": ("gcp/" + ."track-name" | gsub(" ";"-")),
               "name": .children[0].children[0].children[0].text,

--- a/gsuite.sh
+++ b/gsuite.sh
@@ -25,7 +25,7 @@ curl -s 'https://cloud.google.com/products/' \
               "categories":
               [
                 {
-                  "id": (."track-metadata-module_headline" | gsub(" ";"-")),
+                  "id": ("gsuite/" + ."track-metadata-module_headline" | gsub(" ";"-")),
                   "name": ."track-metadata-module_headline"
                 }
               ]
@@ -42,7 +42,7 @@ curl -s 'https://cloud.google.com/products/' \
                 ("gsuite/service/" + .id | sub("/gsuite/"; "/"))
               ] + 
               (
-                ["gsuite/category/\(.categories[] | .id)"] | sort
+                ["gsuite/category/\(.categories[] | (.id | sub("gsuite/"; "")))"] | sort
               )
             )
           }' \

--- a/gsuite.sh
+++ b/gsuite.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+set -e
+
+echo "listing Workspace services"
+CUSTOM_SERVICES=$(cat custom-services/gsuite.json)
+
+curl -s 'https://cloud.google.com/products/' \
+  | pup 'a.cws-card json{}' \
+  | jq -r '.[]
+          # workspace services only
+          | select(.href | startswith("https://workspace.google.com"))
+
+          # drop workspace itself
+          | select(."track-name" != "google workspace")
+
+          # drop workspace essentials, we have those more detailed in custom-services
+          | select(."track-name" != "google workspace essentials")
+
+          | {
+              "id": ("gsuite/" + ."track-name" | gsub(" ";"-")),
+              "name": .children[0].children[0].children[0].text,
+              "summary": .children[0].children[0].children[1].text,
+              "url": (if .href | startswith("https://") then .href else "https://cloud.google.com" + .href end),
+              "categories":
+              [
+                {
+                  "id": (."track-metadata-module_headline" | gsub(" ";"-")),
+                  "name": ."track-metadata-module_headline"
+                }
+              ]
+            }' \
+  | jq -n '. |= [inputs]' \
+  | jq '. | group_by(.id) | map(.[] + {("categories"): map(.categories) | add}) | unique_by(.id)' \
+  | jq '.[] 
+        | . +
+          {
+            "tags":
+            (
+              [
+                "gsuite/platform",
+                ("gsuite/service/" + .id | sub("/gsuite/"; "/"))
+              ] + 
+              (
+                ["gsuite/category/\(.categories[] | .id)"] | sort
+              )
+            )
+          }' \
+  | jq -n '. |= [inputs]' \
+  | jq -r ". += $CUSTOM_SERVICES" \
+  | jq -r 'sort_by(.id)' > data/gsuite.json
+
+echo "done"


### PR DESCRIPTION
This PR addresses Issue #17:

- remove anything that links to to https://workspace.google.com/ from the gcp services
- add gsuite.sh (copied and slightly modified from gcp.sh) to scrape workspace services
- move our static gsuite definitions to dir custom-services so we can keep them
- remove some redundant services like workspace itself and "essentials", which are better covered by our custom service definitions

### Noteworthy

- keep `gsuite` namespace for now, although it's about time we migrated from `gsuite` to `google workspace`.
- scraped services result in some differences in tags from what we defined earlier, but I nothing major