### PR TITLE
remove `SQL Server on Google Cloud` in favor of `Cloud SQL`

### DIFF
--- a/data/gcp.json
+++ b/data/gcp.json
@@ -2974,23 +2974,6 @@
     ]
   },
   {
-    "id": "gcp/sql-server-on-google-cloud",
-    "name": "SQL Server on Google Cloud",
-    "summary": "Options for running SQL Server virtual machines on Google Cloud.",
-    "url": "https://cloud.google.com/sql-server",
-    "categories": [
-      {
-        "id": "compute",
-        "name": "compute"
-      }
-    ],
-    "tags": [
-      "gcp/platform",
-      "gcp/service/sql-server-on-google-cloud",
-      "gcp/category/compute"
-    ]
-  },
-  {
     "id": "gcp/storage-transfer-service",
     "name": "Storage Transfer Service",
     "summary": "Tools and services for transferring your data to Google Cloud.",

--- a/gcp.sh
+++ b/gcp.sh
@@ -22,7 +22,10 @@ curl -s 'https://cloud.google.com/products/' \
                   "name": ."track-metadata-module_headline"
                 }
               ]
-            }' \
+            }
+            
+          # The SQL Server entry is in compute, we delete it in favor of gcp/cloud-sql:
+          | select(.id != "gcp/sql-server-on-google-cloud")' \
   | jq -n '. |= [inputs]' \
   | jq '. | group_by(.id) | map(.[] + {("categories"): map(.categories) | add}) | unique_by(.id)' \
   | jq '.[] 


### PR DESCRIPTION
Fixes #25

(This particular entry is categorized as compute. I don't think we need it as SQL Server is already covered by Cloud SQL)