### PR TITLE
Support finance ticket routing

### DIFF
--- a/data/finance.json
+++ b/data/finance.json
@@ -148,5 +148,200 @@
             "finance/category/bookkeeping",
             "finance/service/company-details"
         ]
+    },
+    {
+        "id": "finance/payment-remittance",
+        "name": "Payment Remittance",
+        "categories": [
+            {
+                "id": "finance/collections",
+                "name": "Collections"
+            }
+        ],
+        "tags": [
+            "finance/platform",
+            "finance/category/collections",
+            "finance/service/payment-remittance"
+        ]
+    },
+    {
+        "id": "finance/invoice-copy",
+        "name": "Invoice Copy",
+        "categories": [
+            {
+                "id": "finance/collections",
+                "name": "Collections"
+            }
+        ],
+        "tags": [
+            "finance/platform",
+            "finance/category/collections",
+            "finance/service/invoice-copy"
+        ]
+    },
+    {
+        "id": "finance/statement-of-account",
+        "name": "Statement of Account",
+        "categories": [
+            {
+                "id": "finance/bookkeeping",
+                "name": "Bookkeeping"
+            }
+        ],
+        "tags": [
+            "finance/platform",
+            "finance/category/bookkeeping",
+            "finance/service/statement-of-account"
+        ]
+    },
+    {
+        "id": "finance/banking-details-needed",
+        "name": "Banking Details Needed",
+        "categories": [
+            {
+                "id": "finance/collections",
+                "name": "Collections"
+            }
+        ],
+        "tags": [
+            "finance/platform",
+            "finance/category/collections",
+            "finance/service/banking-details-needed"
+        ]
+    },
+    {
+        "id": "finance/change-payment-method",
+        "name": "Changing Payment Method",
+        "categories": [
+            {
+                "id": "finance/collections",
+                "name": "Collections"
+            }
+        ],
+        "tags": [
+            "finance/platform",
+            "finance/category/collections",
+            "finance/service/change-payment-method"
+        ]
+    },
+    {
+        "id": "finance/account-reconciliation",
+        "name": "Account Reconciliation",
+        "categories": [
+            {
+                "id": "finance/bookkeeping",
+                "name": "Bookkeeping"
+            }
+        ],
+        "tags": [
+            "finance/platform",
+            "finance/category/bookkeeping",
+            "finance/service/account-reconciliation"
+        ]
+    },
+    {
+        "id": "finance/credit-inquiry",
+        "name": "Credit Inquiry",
+        "categories": [
+            {
+                "id": "finance/account-management",
+                "name": "Account Management"
+            }
+        ],
+        "tags": [
+            "finance/platform",
+            "finance/category/account-management",
+            "finance/service/credit-inquiry"
+        ]
+    },
+    {
+        "id": "finance/update-billing-contact-email",
+        "name": "Update Billing Contact Email",
+        "categories": [
+            {
+                "id": "finance/collections",
+                "name": "Collections"
+            }
+        ],
+        "tags": [
+            "finance/platform",
+            "finance/category/collections",
+            "finance/service/update-billing-contact-email"
+        ]
+    },
+    {
+        "id": "finance/company-details",
+        "name": "Update Company Details",
+        "categories": [
+            {
+                "id": "finance/account-management",
+                "name": "Account Management"
+            }
+        ],
+        "tags": [
+            "finance/platform",
+            "finance/category/account-management",
+            "finance/service/company-details"
+        ]
+    },
+    {
+        "id": "finance/change-currency",
+        "name": "Update Invoice Currency",
+        "categories": [
+            {
+                "id": "finance/collections",
+                "name": "Collections"
+            }
+        ],
+        "tags": [
+            "finance/platform",
+            "finance/category/collections",
+            "finance/service/change-currency"
+        ]
+    },
+    {
+        "id": "finance/change-purchase-order",
+        "name": "Update Purchase Order Number",
+        "categories": [
+            {
+                "id": "finance/collections",
+                "name": "Collections"
+            }
+        ],
+        "tags": [
+            "finance/platform",
+            "finance/category/collections",
+            "finance/service/change-purchase-order"
+        ]
+    },
+    {
+        "id": "finance/estimated-spend-request",
+        "name": "Estimated Spend Request",
+        "categories": [
+            {
+                "id": "finance/account-management",
+                "name": "Account Management"
+            }
+        ],
+        "tags": [
+            "finance/platform",
+            "finance/category/account-management",
+            "finance/service/estimated-spend-request"
+        ]
+    },
+    {
+        "id": "finance/other",
+        "name": "Other",
+        "categories": [
+            {
+                "id": "finance/collections",
+                "name": "Collections"
+            }
+        ],
+        "tags": [
+            "finance/platform",
+            "finance/category/collections",
+            "finance/service/other"
+        ]
     }
 ]

--- a/data/finance.json
+++ b/data/finance.json
@@ -135,7 +135,7 @@
         ]
     },
     {
-        "id": "finance/copmany-details",
+        "id": "finance/company-details",
         "name": "Update Company Details",
         "categories": [
             {

--- a/data/finance.json
+++ b/data/finance.json
@@ -75,21 +75,6 @@
         ]
     },
     {
-        "id": "finance/change-currency",
-        "name": "Change Billing Currency",
-        "categories": [
-            {
-                "id": "finance/bookkeeping",
-                "name": "Bookkeeping"
-            }
-        ],
-        "tags": [
-            "finance/platform",
-            "finance/category/bookkeeping",
-            "finance/service/change-currency"
-        ]
-    },
-    {
         "id": "finance/invoice-reconciliation",
         "name": "Invoice Reconciliation",
         "categories": [
@@ -105,21 +90,6 @@
         ]
     },
     {
-        "id": "finance/invoice-copy",
-        "name": "Request Invoice Copy",
-        "categories": [
-            {
-                "id": "finance/bookkeeping",
-                "name": "Bookkeeping"
-            }
-        ],
-        "tags": [
-            "finance/platform",
-            "finance/category/bookkeeping",
-            "finance/service/invoice-copy"
-        ]
-    },
-    {
         "id": "finance/time-report",
         "name": "Request Time Report",
         "categories": [
@@ -132,21 +102,6 @@
             "finance/platform",
             "finance/category/bookkeeping",
             "finance/service/time-report"
-        ]
-    },
-    {
-        "id": "finance/company-details",
-        "name": "Update Company Details",
-        "categories": [
-            {
-                "id": "finance/bookkeeping",
-                "name": "Bookkeeping"
-            }
-        ],
-        "tags": [
-            "finance/platform",
-            "finance/category/bookkeeping",
-            "finance/service/company-details"
         ]
     },
     {


### PR DESCRIPTION
This adds new Choices for opening Finance Tickets. Customer will be encouraged to use these in the outgoing communication very soon.

Here is the list supplied by Allie Kroll:

![Screenshot 2023-06-15 at 5 21 46 PM](https://github.com/doitintl/cloud-catalog/assets/60910/f20d4aa5-c671-4005-a069-4663c3d12859)

Consolidation with existing categories is documented here: https://docs.google.com/spreadsheets/d/1NW7IgYEyo6aNhJgURKX4Q8s50baPjrlZjtz7ZeyVKkM

As a next step, I'll create triggers that assign the respective group based on the `finance/category/*` tags.