### PR TITLE
Adding cre "platform" - just for ZR to be aware of it

### DIFF
--- a/data/cre.json
+++ b/data/cre.json
@@ -10,7 +10,8 @@
     ],
     "tags": [
       "cre/pro-serv",
-      "cre/pro-serv/aws-wafr"
+      "cre/pro-serv/aws-wafr",
+      "gdr/activity/aws-wafr"
     ]
   }
 ]

--- a/data/cre.json
+++ b/data/cre.json
@@ -1,11 +1,11 @@
 [
   {
     "id": "cre/pro-serv/aws-wafr",
-    "name": "AWS WAfR Session",
+    "name": "AWS Well-Architected Framework Review",
     "categories": [
       {
         "id": "cre/pro-serv",
-        "name": "cre/pro-serv"
+        "name": "DoiT CRE Professional Services"
       }
     ],
     "tags": [

--- a/data/cre.json
+++ b/data/cre.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "cre/pro-serv/aws-wafr",
+    "name": "AWS WAfR Session",
+    "categories": [
+      {
+        "id": "cre/pro-serv",
+        "name": "cre/pro-serv"
+      }
+    ],
+    "tags": [
+      "cre/pro-serv",
+      "cre/pro-serv/aws-wafr"
+    ]
+  }
+]


### PR DESCRIPTION
As part of the [initiative](https://doitintl.atlassian.net/wiki/spaces/CRE/pages/246251521/Automatically+assign+AWS+WAfR+requests) to automatically route AWS WAfR pro-serv requests we'd like the relevant tag to be know to ZenRouter

@alexei-led can you please review for validity? Also, can you please confirm that this CRE "platform" will **not** appear in the CMP ticket creation UI?